### PR TITLE
Update customProjectAttributes to use Moose-Core

### DIFF
--- a/src/BaselineOfFamixTagging/BaselineOfFamixTagging.class.st
+++ b/src/BaselineOfFamixTagging/BaselineOfFamixTagging.class.st
@@ -51,7 +51,7 @@ BaselineOfFamixTagging >> baseline: spec [
 BaselineOfFamixTagging >> customProjectAttributes [
 
 	^ RPackageOrganizer default packages
-		  detect: [ :package | package name = 'BaselineOfFamix' ]
+		  detect: [ :package | package name = 'Moose-Core' ]
 		  ifFound: [ #(  ) ]
 		  ifNone: [ #( #NeedsFamix ) ]
 ]


### PR DESCRIPTION
When having several dependencies such as

```mermaid
flowchart LR
    MooseIDE --> FamixTagging
    FamixTagging --> Famix
    MooseIDE --> Famix
```

When loading the _MooseIDE_ project, the system detects the two requirements of _FamixTagging_ and _Famix_.
Thus, it downloads the project and install in the system the _BaselineOfFamixTagging_ and _BaselineOfFamix_.

Then, _MooseIDE_ will try to load the _BaselineOfFamixTagging_. It looks for the customProjectAttributes and detects that it is present. However, the class `BaselineOfFamix` is present in the system but has never been loaded.

Thus, _BaselineOfFamixTagging_ try to load its packages, but it never loads its famix dependencies which may lead to several error when loading the MooseIDE baseline as one can see in the log (https://github.com/moosetechnology/MooseIDE/actions/runs/3603073918/jobs/6070813327#step:4:1060)

